### PR TITLE
Allow java to see this like kotlin does

### DIFF
--- a/src/main/kotlin/net.evilblock.pidgin/Pidgin.kt
+++ b/src/main/kotlin/net.evilblock.pidgin/Pidgin.kt
@@ -55,7 +55,7 @@ class Pidgin(
 					throw IllegalStateException("First parameter should be of JsonObject type")
 				}
 
-				val messageId = method.getDeclaredAnnotation(IncomingMessageHandler::class.java).id
+				val messageId = method.getDeclaredAnnotation(IncomingMessageHandler::class.java).value
 				listeners.putIfAbsent(messageId, arrayListOf())
 				listeners[messageId]!!.add(MessageListenerData(messageListener, method, messageId))
 			}

--- a/src/main/kotlin/net.evilblock.pidgin/message/handler/IncomingMessageHandler.kt
+++ b/src/main/kotlin/net.evilblock.pidgin/message/handler/IncomingMessageHandler.kt
@@ -2,4 +2,4 @@ package net.evilblock.pidgin.message.handler
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class IncomingMessageHandler(val id: String)
+annotation class IncomingMessageHandler(val value: String)


### PR DESCRIPTION
This allows Java to see 

```
@IncomingMessageHandler("Noob")
```
instead of doing this on Java:

```
@IncomingMessageHandler(id="Noob")
```